### PR TITLE
Updated the digitalnazajednica.slack invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
             <section class="trait">
                 <p><strong>Придружи се Slack каналу</strong> где можеш директно да причаш са другим технолозима и предузетницима.</p>
                  <a
-                    href="https://join.slack.com/t/digitalnazajednica/shared_invite/enQtODEzMzM3Nzg4OTY3LTBiNmNjNzc4ZjZiZTZjODBhYjFhZTEzNmFjMDU3ODNjMTEyNjQ4NGNjYjNiNmZkZjMzMDZiOTc2NGVmZDI3Yzc"
+                    href="https://join.slack.com/t/digitalnazajednica/shared_invite/enQtODUyMTg3MDA3NjY5LWZkNDQ0Njg4NWFjZTcxNGEzOTNhNGE3Y2NmMzlhOTdhODNjOWMxZjk4ZTc4YzY4ZmMwZWUxNDA5ODQ1NWY4NDQ"
                     class="btn">Учлани се на Slack дигиталне заједнице</a><br>
             </section>
 


### PR DESCRIPTION
The previous slack group invite link expired.
I've generated a new slack invite link, and replaced the old slack invite link on the home page